### PR TITLE
FP 307 - Update Webpack Bundle Analyzer options for report generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "nyc": "^13.1.0",
     "opn-cli": "^4.0.0",
     "prettier": "^1.15.2",
-    "standard-version": "^7.1.0",
+    "standard-version": "^8.0.1",
     "trash-cli": "^1.4.0",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.17.0",

--- a/template/config/meta/vue.config.js
+++ b/template/config/meta/vue.config.js
@@ -24,8 +24,8 @@ module.exports = {
       [
 
         // Produces a bundle report for production build. 
-        // Opens in browser automatically.
-        new BundleAnalyzerPlugin(),
+        // Generates a report to be viewed later.
+        new BundleAnalyzerPlugin( {analyzerMode: "static"} ),
 
         // Reduce image size for assets in Production build.
         new ImageminPlugin({


### PR DESCRIPTION
Added the following line to the vue.config.js file 

new BundleAnalyzerPlugin({analyzerMode: "static"})

This was done to prevent the BundleAnalyzer report from hanging during build execution while in a CI/CD context.