### PR TITLE
FP-319 & FP-341

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -142,7 +142,7 @@ function parseUserInput(args: string[], features: string[]) {
   };
 
   // This holds the argument that is expected after <rdvue list>
-  const isFeatures = 'features';
+  const isPlugins = 'plugins';
 
 
   // Magic numbers are not allowed: used to check third argument
@@ -163,7 +163,7 @@ function parseUserInput(args: string[], features: string[]) {
     // OR a Plugin or a Feature Group Type
     // OR if its 'features' which was passed - 'features' is used to list optional modules/features
     if (args[1] !== undefined && (features.includes(args[1]) || isFeatureGroupType(args[1])
-      || isPlugin(args[1]) || args[1] === isFeatures)) {
+      || isPlugin(args[1]) || args[1] === isPlugins)) {
 
       returnObject.feature = args[1];
 

--- a/template/config/meta/tsconfig.json
+++ b/template/config/meta/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "es6",
+    "module": "esnext",
     "strict": true,
     "jsx": "preserve",
     "importHelpers": true,


### PR DESCRIPTION
This PR addresses two items:
- FP-319: refactors the list command. `rdvue list features` is now `rdvue list plugins`
- FP-341: refactors the template's tsconfig to use esnext as the module instead of es6.