### PR TITLE
FP-351/remove null when generating presets

### DIFF
--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -25,7 +25,6 @@ import {
 } from '../constants/constants';
 import { Config } from '../types/cli';
 import { FeatureNameObject, Files } from '../types/index';
-import { type } from 'os';
 
 const Spinner = CLI.Spinner;
 const fs = bluebirdPromise.promisifyAll(fileSystem);

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -25,6 +25,7 @@ import {
 } from '../constants/constants';
 import { Config } from '../types/cli';
 import { FeatureNameObject, Files } from '../types/index';
+import { type } from 'os';
 
 const Spinner = CLI.Spinner;
 const fs = bluebirdPromise.promisifyAll(fileSystem);
@@ -338,7 +339,9 @@ async function copyAndUpdateFiles(
 
 async function appendToFile(location: string, data: any) {
   await fs.appendFile(location, data, err => {
-    console.log(err);
+    if(err instanceof Error){
+      console.log(err);
+    }
   });
 }
 

--- a/src/modules/new/index.ts
+++ b/src/modules/new/index.ts
@@ -344,7 +344,8 @@ async function run(operation: Command, USAGE: CLI): Promise<any> {
         }
 
         if(currentConfig.projectTheme !== undefined && currentConfig.projectTheme.length > 0) {
-          await util.updateDynamicImportsAndExports(
+         
+            await util.updateDynamicImportsAndExports(
             'theme',
             currentConfig.projectTheme,
             '_all.scss'
@@ -377,9 +378,10 @@ async function run(operation: Command, USAGE: CLI): Promise<any> {
             // [11]b Create a section break
             util.sectionBreak();
             // tslint:disable-next-line:no-console
+
             console.log(chalk.magenta
                 (`The ${userFeature} "${answers[nameKey] ?? ''}" has been generated.`));
-        }
+            }
 
         return true;
     } catch (err) {

--- a/template/buefy/manifest.json
+++ b/template/buefy/manifest.json
@@ -4,7 +4,7 @@
   "group": false,
   "hasRoutes": true,
   "hasProjectModules": true,
-  "description": "Generate filesfiles/dependences needed for the buefy UI Group.",
+  "description": "Generate files/dependencies needed for the buefy UI Group.",
   "sourceDirectory": "./",
   "installDirectory": "./",
   "files": [

--- a/template/buefy/manifest.json
+++ b/template/buefy/manifest.json
@@ -4,7 +4,7 @@
   "group": false,
   "hasRoutes": true,
   "hasProjectModules": true,
-  "description": "Generate files/dependencies needed for the buefy UI Group.",
+  "description": "Generate files/dependencies needed for the buefy UI Library.",
   "sourceDirectory": "./",
   "installDirectory": "./",
   "files": [


### PR DESCRIPTION
The null value was being generated as a result of console logging an err variable from a callback without checking it first