### PR TITLE
Fp 352/project name needs to be asked as the first thing when generating a project with a preset

### DIFF
--- a/src/modules/new/index.ts
+++ b/src/modules/new/index.ts
@@ -237,7 +237,7 @@ async function run(operation: Command, USAGE: CLI): Promise<any> {
                 USAGE
             );
 
-            // [2]d Optional mpdule questions need to be asked after project name
+            // [2]d Optional module questions need to be asked after project name is requested.
             modulesToInstall = await OPTIONAL_MODULES.requestPresetSelection();
 
             // 2[e] Loads in optional modules after project has been setup

--- a/src/modules/new/index.ts
+++ b/src/modules/new/index.ts
@@ -237,7 +237,7 @@ async function run(operation: Command, USAGE: CLI): Promise<any> {
                 USAGE
             );
 
-            // [2]d Optional mpdule questions need to be asked after project name.
+            // [2]d Optional mpdule questions need to be asked after project name
             modulesToInstall = await OPTIONAL_MODULES.requestPresetSelection();
 
             // 2[e] Loads in optional modules after project has been setup

--- a/src/modules/new/index.ts
+++ b/src/modules/new/index.ts
@@ -213,8 +213,7 @@ async function run(operation: Command, USAGE: CLI): Promise<any> {
         // [2] Check if the user requested a new project
         if (isProject) {
 
-            const modulesToInstall = await OPTIONAL_MODULES.requestPresetSelection();
-
+            let modulesToInstall: Array<string>;
             // [2]b Get required config
             await run(
                 {
@@ -238,6 +237,8 @@ async function run(operation: Command, USAGE: CLI): Promise<any> {
                 USAGE
             );
 
+            // [2]d Optional mpdule questions need to be asked after project name.
+            modulesToInstall = await OPTIONAL_MODULES.requestPresetSelection();
 
             // 2[e] Loads in optional modules after project has been setup
             for (const module of modulesToInstall) {


### PR DESCRIPTION
The optional modules request preset selection was refactored so that the project name question can be be asked first.