### PR TITLE
Added changes to the menu to reflect the README

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -11,21 +11,33 @@ function USAGE_TEMPLATE(
     service = 'rdvue',
     action = '<action>',
     feature = '<feature>',
-    featureName = '<feature name>',
-    featureGroup = '<feature group>',
-    options = '[options]'): Menu[] {
+    plugin = '<plugin>',
+    pluginGroup = '<plugin group>',
+    projectName = '<project-name>',
+    featureName = '<feature-name>'): Menu[] {
     return [
         {
-            header: 'Usage:',
-            content: `$ ${chalk.yellow(service)} ${chalk.green(action)} ${chalk.yellow(featureGroup)} ${chalk.red('or')} ${chalk.magenta(feature)} ${chalk.grey(featureName)} ${chalk.cyan(options)}`
+            header: '',
+            content: `npx ${chalk.yellow(service)} ${chalk.green(action)} [${chalk.yellow(feature)}${chalk.red('|')}${chalk.yellow(plugin)}${chalk.red('|')}${chalk.yellow(pluginGroup)}] [${chalk.magenta(projectName)}${chalk.red('|')}${chalk.grey(featureName)}]`
         },
         {
             header: 'Actions:',
             content: [
                 {
-                    name: `${chalk.green('generate')}`,
-                    shortcut: `${chalk.green('g')}`,
-                    summary: 'Creates new feature',
+                    name: `${chalk.green('generate | g')}`,
+                    shortcut: '-',
+                    summary: 'Creates new Feature,',
+
+                },
+                {
+                    name: `${chalk.green('add')}`,
+                    shortcut: '-',
+                    summary: 'Add a Plugin to a project.',
+                },
+                {
+                    name: `${chalk.green('add-group')}`,
+                    shortcut: '-',
+                    summary: 'Add a Plugin to a project by selecting from preset groups.',
                 }
             ]
         },
@@ -33,9 +45,9 @@ function USAGE_TEMPLATE(
             header: 'Options:',
             content: [
                 {
-                    name: `${chalk.cyan('--help')}`,
-                    shortcut: `${chalk.cyan('-h')}`,
-                    summary: 'Display Help Menu',
+                    name: `${chalk.cyan('--help | -h')}`,
+                    shortcut: '-',
+                    summary: 'Show help information.',
                 }
             ]
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ function populateFeatureGroupMenu(groups: Group[], index: number) {
         .includes('Groups:'))
     ) {
       CLI_DESCRIPTION.general.menu.splice(index, 0, {
-        header: 'Groups:',
+        header: 'Plugin Groups (Choose a plugin from preset groupings):',
         content: [],
       });
     }
@@ -139,7 +139,7 @@ async function populateCLIMenu(features: string[], requiredFeatures: string[],
     ) {
 
       CLI_DESCRIPTION.general.menu.splice(index, 0, {
-        header: 'Features:',
+        header: `Features:`,
         content: [],
       });
     }
@@ -149,7 +149,7 @@ async function populateCLIMenu(features: string[], requiredFeatures: string[],
       contentPopulate(
         CLI_DESCRIPTION.general.menu,
         `${chalk.magenta('project')}`,
-        'Generate a new project.', index
+        'Scaffold a new RDVue project.', index
       );
     }
 

--- a/src/lib/helper-functions.ts
+++ b/src/lib/helper-functions.ts
@@ -5,6 +5,9 @@
 import { CLI_DESCRIPTION } from '../index';
 import { Config, Content, Menu, ModuleDescriptor, Group } from '../types/cli';
 
+
+const shortcut : string = ' - ' ;
+
 /**
  * Descripton: Based on the feature inputed the function will assign the configuration
  * @param feature - the feature which the user would like the configuration of.
@@ -36,7 +39,7 @@ export function contentPopulate(
     let menuContent: Content[];
     menuContent = objectToBePopulated[index].content as Content[];
 
-    menuContent.push({ name, summary });
+    menuContent.push({ name, shortcut , summary});
   }
 }
 

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -121,7 +121,7 @@ export interface Menu {
   content: string | Content[];
 }
 
-// Interface fot the content type
+// Interface for the content type
 export interface Content {
   name: string;
   summary: string;

--- a/template/buefy/manifest.json
+++ b/template/buefy/manifest.json
@@ -4,7 +4,7 @@
   "group": false,
   "hasRoutes": true,
   "hasProjectModules": true,
-  "description": "Generate files/dependencies needed for the buefy UI Library.",
+  "description": "Add Buefy support to an existing project.",
   "sourceDirectory": "./",
   "installDirectory": "./",
   "files": [

--- a/template/component/manifest.json
+++ b/template/component/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "name": "component",
-  "description": "Generate a basic component.",
+  "description": "Generate a new Component module.",
   "arguments": [
     {
       "name": "componentNameKebab",

--- a/template/layout/manifest.json
+++ b/template/layout/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "name": "layout",
-  "description": "Generate a basic layout.",
+  "description": "Generate a new Page Layout.",
   "arguments": [
     {
       "name": "layoutNameKebab",

--- a/template/localization/manifest.json
+++ b/template/localization/manifest.json
@@ -2,7 +2,7 @@
   "version": 1,
   "name": "localization",
   "group": false,
-  "description": "Generate files needed for basic localization.",
+  "description": "Add i18n localization support to an existing project.",
   "sourceDirectory": "./",
   "installDirectory": "./",
   "files": [

--- a/template/page/manifest.json
+++ b/template/page/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "name": "page",
-  "description": "Generate a basic page.",
+  "description": "Generate a new Page module.",
   "arguments": [{
       "name": "pageNameKebab",
       "type": "string",

--- a/template/service/manifest.json
+++ b/template/service/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "name": "service",
-  "description": "Generate a basic service.",
+  "description": "Generate a new Service module.layer",
   "arguments": [{
       "name": "serviceNameKebab",
       "type": "string",

--- a/template/template.json
+++ b/template/template.json
@@ -15,19 +15,11 @@
       "private": false
     },
     {
-      "name": "service",
-      "private": false
-    },
-    {
-      "name": "model",
-      "private": false
-    },
-    {
       "name": "page",
       "private": false
     },
     {
-      "name": "sm",
+      "name": "service",
       "private": false
     },
     {
@@ -36,10 +28,9 @@
     }
   ],
   "plugins": [
-    "localization",
-    "storybook",
+    "buefy",
     "vuetify",
-    "buefy"
+    "localization"
   ],
   "project": {
     "features": [
@@ -65,15 +56,8 @@
       "plugins": [
         "auth"
       ],
-      "question": "[EXPERIMENTAL] Which authentication library would you like to install?"
-    },
-    {
-      "name": "locale",
-      "isMultipleChoice": false,
-      "plugins": [
-        "localization"
-      ],
-      "question": "Which localization library would you like to install?"
+      "question": "[EXPERIMENTAL] Which authentication library would you like to install?",
+      "description": "Provides plugins which generate pages, components and data models to support common authentication scenarios."
     },
     {
       "name": "ui",
@@ -82,6 +66,7 @@
         "vuetify",
         "buefy"
       ],
+      "description": "Provides plugins which add UI libraries or functionalities.",
       "question": "Which UI library would you like to install?"
     }
   ],

--- a/template/vuetify/manifest.json
+++ b/template/vuetify/manifest.json
@@ -2,7 +2,7 @@
   "version": 1,
   "name": "vuetify",
   "group": false,
-  "description": "Generate files/dependences needed for the vuetify UI Group.",
+  "description": "Add Vuetify support to an existing project.",
   "sourceDirectory": "./",
   "installDirectory": "./",
   "files": [


### PR DESCRIPTION
The description for the Features menu is missing. The menu seems to break every time I tried to modify it, and I'm not sure why. Also, for the Plugins group description, I reformatted it as "Plugin Groups (Choose a plugin from preset groupings):" instead of what's in the README, which is "Plugin Groups:  -  Choose a plugin from preset groupings", since the hyphens weren't aligning with the text under it. 

On my computer the `npx rdvue <action> [<feature>|<plugin>|<plugin group>] [<project-name>|<feature-name>]` breaks into a new line  at "<project-" every time it is run. It should adjust accordingly to the console width but it wasn't happening, no matter how I adjusted the size of the terminal I was using. 