### PR TITLE
SEPA-406: Remove linter ignore statements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,80 +1,98 @@
 {
-	"extends": [
-		"oclif",
-		"oclif-typescript"
-	],
-	"env": {
-		"es6": true,
-		"browser": true,
-		"node": true
-	},
-	"parser": "babel-eslint",
+  "extends": [
+    "oclif",
+    "oclif-typescript"
+  ],
+  "env": {
+    "es6": true,
+    "browser": true,
+    "node": true,
+    "mocha": true
+  },
+  "parser": "babel-eslint",
   "parserOptions": {
     "sourceType": "module"
   },
-	"plugins": ["@typescript-eslint"],
+  "plugins": [
+    "@typescript-eslint"
+  ],
   "rules": {
-		"no-console": 1,		
-		"no-extra-semi": 2,
-		"semi": [2, "always"],
-		"semi-spacing": 2,
-		"quotes": [2, "single"],
-		"indent": [2, 2, {"SwitchCase": 1}],
-		"interface-name": 0,
-		"object-literal-sort-keys": 0,
-		"no-consecutive-blank-lines": 0,
-		"no-any": 0,
-		"no-var": 0,
-		"no-cond-assign": 2,
-		"no-debugger": 2,
-		"no-duplicate-imports": 2,
-		"no-empty": 2,
-		"no-eval": 2,
-		"no-invalid-this": 2,
-		"no-irregular-whitespace": 2,
-		"no-return-await": 2,
-		"no-trailing-spaces": 2,
-		"no-empty-character-class": 2,
-		"no-unsafe-finally": 2,
-		"no-unused-vars": 2,
-		"no-unused-expressions": 2,
-		"no-undef": 2,
-		"array-type": 0,
-		"require-await": 2,
-		"prefer-arrow-callback": 2,
-		"arrow-spacing": 2,
-		"spaced-comment": 2,
-		"curly": 2,
-		"complexity": 2,
-		"max-classes-per-file": [
-			2,
-			1
-		],
-		"max-len": [
-			2,
-			1000
-		],
-		"max-lines": [
-			2,
-			200
-		],
-		"new-parens": 2,
-		"newline-before-return": 2,
-		"newline-per-chained-call": 2,
-		"only-arrow-functions": 0,
-		"prefer-const": 2,
-		"prefer-object-spread": 2,
-		"prefer-template": 2,
-		"radix": 2,
-		"no-else-return": 2,
-		"object-curly-spacing": ["error", "always"],
-		"space-before-function-paren": 2,
-		"space-within-parens": 0,
-		"no-eq-null": 2,
-		"comma-dangle": 2,
-		"eqeqeq": 2,
-		"valid-typeof": 2,
-		"block-scoped-var": 2,
-		"interface-over-type-literal": 0
-	}
+    "no-console": 1,
+    "no-extra-semi": 2,
+    "semi": [
+      2,
+      "always"
+    ],
+    "semi-spacing": 2,
+    "quotes": [
+      2,
+      "single"
+    ],
+    "indent": [
+      2,
+      2,
+      {
+        "SwitchCase": 1
+      }
+    ],
+    "interface-name": 0,
+    "object-literal-sort-keys": 0,
+    "no-consecutive-blank-lines": 0,
+    "no-any": 0,
+    "no-var": 0,
+    "no-cond-assign": 2,
+    "no-debugger": 2,
+    "no-duplicate-imports": 2,
+    "no-empty": 2,
+    "no-eval": 2,
+    "no-invalid-this": 2,
+    "no-irregular-whitespace": 2,
+    "no-return-await": 2,
+    "no-trailing-spaces": 2,
+    "no-empty-character-class": 2,
+    "no-unsafe-finally": 2,
+    "no-unused-vars": 2,
+    "no-unused-expressions": 2,
+    "no-undef": 2,
+    "array-type": 0,
+    "require-await": 2,
+    "prefer-arrow-callback": 2,
+    "arrow-spacing": 2,
+    "spaced-comment": 2,
+    "curly": 2,
+    "complexity": 2,
+    "max-classes-per-file": [
+      2,
+      1
+    ],
+    "max-len": [
+      2,
+      1000
+    ],
+    "max-lines": [
+      2,
+      200
+    ],
+    "new-parens": 2,
+    "newline-before-return": 2,
+    "newline-per-chained-call": 2,
+    "only-arrow-functions": 0,
+    "prefer-const": 2,
+    "prefer-object-spread": 2,
+    "prefer-template": 2,
+    "radix": 2,
+    "no-else-return": 2,
+    "object-curly-spacing": [
+      "error",
+      "always"
+    ],
+    "space-before-function-paren": 2,
+    "space-within-parens": 0,
+    "no-eq-null": 2,
+    "comma-dangle": 2,
+    "eqeqeq": 2,
+    "valid-typeof": 2,
+    "block-scoped-var": 2,
+    "interface-over-type-literal": 0
+  }
 }

--- a/src/commands/add/component.ts
+++ b/src/commands/add/component.ts
@@ -7,6 +7,13 @@ import { checkProjectValidity, parseComponentName, toKebabCase, toPascalCase, is
 import { CLI_COMMANDS, CLI_STATE, DOCUMENTATION_LINKS } from '../../lib/constants';
 
 const TEMPLATE_FOLDERS = ['component'];
+const CUSTOM_ERROR_CODES = [
+  'project-invalid',
+  'failed-match-and-replace',
+  'missing-template-file',
+  'missing-template-folder',
+];
+
 export default class Component extends Command {
   static description = 'add a new Component module.'
 
@@ -19,8 +26,7 @@ export default class Component extends Command {
   ]
 
   // override Command class error handler
-  // eslint-disable-next-line require-await
-  async catch(error: Error): Promise<any> {
+  catch(error: Error): Promise<any> {
     const errorMessage = error.message;
     const isValidJSON = isJsonString(errorMessage);
     const parsedError = isValidJSON ? JSON.parse(errorMessage) : {};
@@ -34,20 +40,13 @@ export default class Component extends Command {
     }
 
     // handle errors thrown with known error codes
-    switch (customErrorCode) {
-      case 'project-invalid': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'failed-match-and-replace': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'missing-template-file': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'missing-template-folder': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      default: throw new Error(customErrorMessage);
+    if (CUSTOM_ERROR_CODES.includes(customErrorCode)) {
+      this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
+    } else {
+      throw new Error(customErrorMessage);
     }
 
-    // exit with status code
-    // this.exit(1)
+    return Promise.resolve();
   }
 
   async run(): Promise<void> {

--- a/src/commands/add/index.ts
+++ b/src/commands/add/index.ts
@@ -50,8 +50,9 @@ export default class Add extends Command {
     `);
   }
 
-  // eslint-disable-next-line require-await
-  async run(): Promise<void> {
+  run(): Promise<void> {
     this.showHelp();
+
+    return Promise.resolve();
   }
 }

--- a/src/commands/add/page.ts
+++ b/src/commands/add/page.ts
@@ -7,6 +7,13 @@ import { checkProjectValidity, parsePageName, toKebabCase, toPascalCase, isJsonS
 import { CLI_COMMANDS, CLI_STATE, DOCUMENTATION_LINKS } from '../../lib/constants';
 
 const TEMPLATE_FOLDERS = ['page'];
+const CUSTOM_ERROR_MESSAGES = [
+  'project-invalid',
+  'failed-match-and-replace',
+  'missing-template-file',
+  'missing-template-folder',
+];
+
 export default class Page extends Command {
   static description = 'add a new Page module.'
 
@@ -19,8 +26,7 @@ export default class Page extends Command {
   ]
 
   // override Command class error handler
-  // eslint-disable-next-line require-await
-  async catch(error: Error): Promise<any> {
+  catch(error: Error): Promise<any> {
     const errorMessage = error.message;
     const isValidJSON = isJsonString(errorMessage);
     const parsedError = isValidJSON ? JSON.parse(errorMessage) : {};
@@ -34,20 +40,13 @@ export default class Page extends Command {
     }
 
     // handle errors thrown with known error codes
-    switch (customErrorCode) {
-      case 'project-invalid': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'failed-match-and-replace': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'missing-template-file': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'missing-template-folder': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      default: throw new Error(customErrorMessage);
+    if (CUSTOM_ERROR_MESSAGES.includes(customErrorCode)) {
+      this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
+    } else {
+      throw new Error(customErrorMessage);
     }
 
-    // exit with status code
-    // this.exit(1)
+    return Promise.resolve();
   }
 
   async run(): Promise<void> {

--- a/src/commands/add/service.ts
+++ b/src/commands/add/service.ts
@@ -7,6 +7,12 @@ import { checkProjectValidity, parseServiceName, toKebabCase, toPascalCase, isJs
 import { CLI_COMMANDS, CLI_STATE, DOCUMENTATION_LINKS } from '../../lib/constants';
 
 const TEMPLATE_FOLDERS = ['service'];
+const CUSTOM_ERROR_CODES = [
+  'project-invalid',
+  'failed-match-and-replace',
+  'missing-template-file',
+];
+
 export default class Service extends Command {
   static description = 'add a new Service module.'
 
@@ -19,8 +25,7 @@ export default class Service extends Command {
   ]
 
   // override Command class error handler
-  // eslint-disable-next-line require-await
-  async catch(error: Error): Promise<any> {
+  catch(error: Error): Promise<any> {
     const errorMessage = error.message;
     const isValidJSON = isJsonString(errorMessage);
     const parsedError = isValidJSON ? JSON.parse(errorMessage) : {};
@@ -34,18 +39,13 @@ export default class Service extends Command {
     }
 
     // handle errors thrown with known error codes
-    switch (customErrorCode) {
-      case 'project-invalid': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'failed-match-and-replace': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'missing-template-file': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      default: throw new Error(customErrorMessage);
+    if (CUSTOM_ERROR_CODES.includes(customErrorCode)) {
+      this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
+    } else {
+      throw new Error(customErrorMessage);
     }
 
-    // exit with status code
-    // this.exit(1)
+    return Promise.resolve();
   }
 
   async run(): Promise<void> {

--- a/src/commands/add/store.ts
+++ b/src/commands/add/store.ts
@@ -7,6 +7,13 @@ import { checkProjectValidity, parseStoreModuleName, toKebabCase, toPascalCase, 
 import { CLI_COMMANDS, CLI_STATE, DOCUMENTATION_LINKS } from '../../lib/constants';
 
 const TEMPLATE_FOLDERS = ['store'];
+const CUSTOM_ERROR_CODES = [
+  'project-invalid',
+  'failed-match-and-replace',
+  'missing-template-file',
+  'missing-template-folder',
+];
+
 export default class StoreModule extends Command {
   static description = 'add a new Store module.'
 
@@ -19,8 +26,7 @@ export default class StoreModule extends Command {
   ]
 
   // override Command class error handler
-  // eslint-disable-next-line require-await
-  async catch(error: Error): Promise<any> {
+  catch(error: Error): Promise<any> {
     const errorMessage = error.message;
     const isValidJSON = isJsonString(errorMessage);
     const parsedError = isValidJSON ? JSON.parse(errorMessage) : {};
@@ -34,20 +40,13 @@ export default class StoreModule extends Command {
     }
 
     // handle errors thrown with known error codes
-    switch (customErrorCode) {
-      case 'project-invalid': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'failed-match-and-replace': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'missing-template-file': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'missing-template-folder': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      default: throw new Error(customErrorMessage);
+    if (CUSTOM_ERROR_CODES.includes(customErrorCode)) {
+      this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
+    } else {
+      throw new Error(customErrorMessage);
     }
 
-    // exit with status code
-    // this.exit(1)
+    return Promise.resolve();
   }
 
   async run(): Promise<void> {

--- a/src/commands/create-project/index.ts
+++ b/src/commands/create-project/index.ts
@@ -15,6 +15,12 @@ import {
   PLUGIN_PRESET_LIST,
 } from '../../lib/constants';
 
+const CUSTOM_ERROR_CODES = [
+  'existing-project',
+  'existing-folder',
+  'file-not-changed',
+];
+
 export default class CreateProject extends Command {
   static description = 'create a new rdvue project'
 
@@ -32,8 +38,7 @@ export default class CreateProject extends Command {
   ]
 
   // override Command class error handler
-  // eslint-disable-next-line require-await
-  async catch(error: Error): Promise<any> {
+  catch(error: Error): Promise<any> {
     const errorMessage = error.message;
     const isValidJSON = isJsonString(errorMessage);
     const parsedError = isValidJSON ? JSON.parse(errorMessage) : {};
@@ -47,18 +52,13 @@ export default class CreateProject extends Command {
     }
 
     // handle errors thrown with known error codes
-    switch (customErrorCode) {
-      case 'existing-project': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'existing-folder': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'file-not-changed': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      default: throw new Error(customErrorMessage);
+    if (CUSTOM_ERROR_CODES.includes(customErrorCode)) {
+      this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
+    } else {
+      throw new Error(customErrorMessage);
     }
 
-    // exit with status code
-    // this.exit(1)
+    return Promise.resolve();
   }
 
   async run(): Promise<void> {

--- a/src/commands/plugin/buefy.ts
+++ b/src/commands/plugin/buefy.ts
@@ -13,6 +13,12 @@ import { injectImportsIntoMain } from '../../lib/plugins';
 
 const TEMPLATE_FOLDERS = ['buefy'];
 const TEMPLATE_MIN_VERSION_SUPPORTED = 2;
+const CUSTOM_ERROR_CODES = [
+  'project-invalid',
+  'missing-template-file',
+  'missing-template-folder',
+  'dependency-install-error',
+];
 
 export default class Buefy extends Command {
   static description = 'lightweigth UI components for Vuejs'
@@ -26,8 +32,7 @@ export default class Buefy extends Command {
   static args = []
 
   // override Command class error handler
-  // eslint-disable-next-line require-await
-  async catch(error: Error): Promise<any> {
+  catch(error: Error): Promise<any> {
     const errorMessage = error.message;
     const isValidJSON = isJsonString(errorMessage);
     const parsedError = isValidJSON ? JSON.parse(errorMessage) : {};
@@ -41,17 +46,13 @@ export default class Buefy extends Command {
     }
 
     // handle errors thrown with known error codes
-    switch (customErrorCode) {
-      case 'project-invalid': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'missing-template-file': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'missing-template-folder': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'dependency-install-error': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      default: throw new Error(customErrorMessage);
+    if (CUSTOM_ERROR_CODES.includes(customErrorCode)) {
+      this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
+    } else {
+      throw new Error(customErrorMessage);
     }
+
+    return Promise.resolve();
   }
 
   async run(): Promise<void> {

--- a/src/commands/plugin/index.ts
+++ b/src/commands/plugin/index.ts
@@ -56,8 +56,9 @@ export default class Plugin extends Command {
     `);
   }
 
-  // eslint-disable-next-line require-await
-  async run(): Promise<void> {
+  run(): Promise<void> {
     this.showHelp();
+
+    return Promise.resolve();
   }
 }

--- a/src/commands/plugin/vuetify.ts
+++ b/src/commands/plugin/vuetify.ts
@@ -13,6 +13,12 @@ import { injectImportsIntoMain, injectModulesIntoMain } from '../../lib/plugins'
 
 const TEMPLATE_FOLDERS = ['vuetify'];
 const TEMPLATE_MIN_VERSION_SUPPORTED = 2;
+const CUSTOM_ERROR_CODES = [
+  'project-invalid',
+  'missing-template-file',
+  'missing-template-folder',
+  'dependency-install-error',
+];
 
 export default class Vuetify extends Command {
   static description = 'lightweigth UI components for Vuejs'
@@ -26,8 +32,7 @@ export default class Vuetify extends Command {
   static args = []
 
   // override Command class error handler
-  // eslint-disable-next-line require-await
-  async catch(error: Error): Promise<any> {
+  catch(error: Error): Promise<any> {
     const errorMessage = error.message;
     const isValidJSON = isJsonString(errorMessage);
     const parsedError = isValidJSON ? JSON.parse(errorMessage) : {};
@@ -41,20 +46,13 @@ export default class Vuetify extends Command {
     }
 
     // handle errors thrown with known error codes
-    switch (customErrorCode) {
-      case 'project-invalid': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'missing-template-file': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'missing-template-folder': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      case 'dependency-install-error': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      default: throw new Error(customErrorMessage);
+    if (CUSTOM_ERROR_CODES.includes(customErrorCode)) {
+      this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
+    } else {
+      throw new Error(customErrorMessage);
     }
 
-    // exit with status code
-    // this.exit(1)
+    return Promise.resolve();
   }
 
   async run(): Promise<void> {
@@ -135,8 +133,7 @@ export default class Vuetify extends Command {
       try {
         injectModulesIntoMain(projectRoot, mainModules);
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error(error);
+        this.error(error);
       }
     } else {
       // FP-414: backwards compatibility

--- a/src/commands/upgrade/index.ts
+++ b/src/commands/upgrade/index.ts
@@ -5,6 +5,10 @@ import chalk from 'chalk';
 import { checkProjectValidity, isJsonString } from '../../lib/utilities';
 import { CLI_COMMANDS, CLI_STATE, TEMPLATE_REPO, TEMPLATE_ROOT, TEMPLATE_TAG } from '../../lib/constants';
 
+const CUSTOM_ERROR_CODES = [
+  'project-invalid',
+];
+
 export default class Upgrade extends Command {
   static description = 'Specify the rdvue template version for a project'
 
@@ -17,8 +21,7 @@ export default class Upgrade extends Command {
   ]
 
   // override Command class error handler
-  // eslint-disable-next-line require-await
-  async catch(error: Error): Promise<any> {
+  catch(error: Error): Promise<any> {
     const errorMessage = error.message;
     const isValidJSON = isJsonString(errorMessage);
     const parsedError = isValidJSON ? JSON.parse(errorMessage) : {};
@@ -32,14 +35,13 @@ export default class Upgrade extends Command {
     }
 
     // handle errors thrown with known error codes
-    switch (customErrorCode) {
-      case 'project-invalid': this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
-        break;
-      default: throw new Error(customErrorMessage);
+    if (CUSTOM_ERROR_CODES.includes(customErrorCode)) {
+      this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
+    } else {
+      throw new Error(customErrorMessage);
     }
 
-    // exit with status code
-    // this.exit(1)
+    return Promise.resolve();
   }
 
   async run(): Promise<void> {

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,6 +1,7 @@
 import Help from '@oclif/plugin-help';
 import { Command, Topic } from '@oclif/config';
 import chalk from 'chalk';
+import { log } from './lib/stdout';
 
 export default class MyHelpClass extends Help {
   // acts as a 'router'
@@ -8,8 +9,7 @@ export default class MyHelpClass extends Help {
   // calls one of showRootHelp, showTopicHelp,
   // or showCommandHelp
   showRootHelp(): void {
-    // eslint-disable-next-line no-console
-    console.log(`
+    log(`
         npx ${chalk.blue('rdvue')} <action>
 
         Actions:
@@ -31,21 +31,16 @@ export default class MyHelpClass extends Help {
     const subTopics = this.sortedTopics.filter(t => t.name.startsWith(`${name}:`) && t.name.split(':').length === depth + 1);
     const commands = this.sortedCommands.filter(c => c.id.startsWith(`${name}:`) && c.id.split(':').length === depth + 1);
 
-    // eslint-disable-next-line no-console
-    console.log(this.formatTopic(topic));
+    log(this.formatTopic(topic));
 
     if (subTopics.length > 0) {
-      // eslint-disable-next-line no-console
-      console.log(this.formatTopics(subTopics));
-      // eslint-disable-next-line no-console
-      console.log('');
+      log(this.formatTopics(subTopics));
+      log('');
     }
 
     if (commands.length > 0) {
-      // eslint-disable-next-line no-console
-      console.log(this.formatCommands(commands));
-      // eslint-disable-next-line no-console
-      console.log('');
+      log(this.formatCommands(commands));
+      log('');
     }
   }
 
@@ -80,8 +75,7 @@ export default class MyHelpClass extends Help {
         return `\n\t    --${flag.name} | -${flag.char}${new Array(numOfSpaces + 1).join(' ')}- ${flag.description}`;
       });
 
-    // eslint-disable-next-line no-console
-    console.log(`
+    log(`
         Usage:
             npx ${chalk.blue('rdvue')} ${commandId} ${argNames}
 

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -9,6 +9,7 @@ import { Files, InjectOptions } from '../modules';
 const replace = require('replace-in-file');
 import { hasKebab } from './utilities';
 import { DYNAMIC_OBJECTS, TEMPLATE_CONFIG_FILENAME, TEMPLATE_ROOT } from './constants';
+import { log } from '../lib/stdout';
 
 const UTF8 = 'utf-8';
 const fs = bluebirdPromise.promisifyAll(fileSystem);
@@ -76,7 +77,7 @@ function readConfigFile(filePath: string): any {
  * @param {string} projectRoot -
  * @returns {[any]} -
  */
-function parseModuleConfig(folderList: string[], projectRoot: string): {name: string, moduleTemplatePath: string, manifest: any}[] {
+function parseModuleConfig(folderList: string[], projectRoot: string): { name: string, moduleTemplatePath: string, manifest: any }[] {
   return folderList.map(folder => {
     const moduleTemplatePath = path.join(projectRoot, TEMPLATE_ROOT, folder);
     const configFilePath = path.join(moduleTemplatePath, TEMPLATE_CONFIG_FILENAME);
@@ -100,7 +101,6 @@ function writeFile(filePath: string, data: string): boolean {
   try {
     fs.writeFileSync(filePath, data);
   } catch (error) {
-    // eslint:disable-next-line:no-console
     success = false;
     throw new Error('failed to write to file');
   }
@@ -451,8 +451,7 @@ function parseDynamicObjects(
     const originalObjectString = objectInProject.slice(0, -2);
 
     // Append the new information and close files after changes
-    objectStringToBeWritten = `${originalObjectString}${modifiedJSONData.trim()},${objectName === DYNAMIC_OBJECTS.Routes ? ']' : '}'
-    };`;
+    objectStringToBeWritten = `${originalObjectString}${modifiedJSONData.trim()},${objectName === DYNAMIC_OBJECTS.Routes ? ']' : '}'};`;
   }
 
   // 1[c] Once everything is clear write the updated file into the ./rdvue foldler
@@ -508,8 +507,7 @@ async function updateDynamicImportsAndExports(
   const SOURCE_DIRECTORY = 'src';
 
   if (projectRoot === null) {
-    // eslint-disable-next-line no-console
-    console.log('Project location was not found');
+    log('Project location was not found');
   } else {
     const fileLocation = path.join(projectRoot, SOURCE_DIRECTORY, folderName, fileName);
     if (fileExists(fileLocation)) {
@@ -521,8 +519,7 @@ async function updateDynamicImportsAndExports(
         });
       }
     } else {
-      // eslint-disable-next-line no-console
-      console.log(`${fileLocation} - Does not exist`);
+      log(`${fileLocation} - Does not exist`);
     }
   }
 }

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -264,6 +264,7 @@ async function readAndUpdateFeatureFiles(
   pascalName: string,
 ): Promise<void> {
   let filePath = '';
+  const promisedUpdates = [];
 
   // [3] For each file in the list
   for (const file of files) {
@@ -281,10 +282,8 @@ async function readAndUpdateFeatureFiles(
         if (contentBlock && contentBlock.matchRegex) {
           // [4] Get the content at the desired file path
           const fileContent = readFile(filePath);
-
           // [5] Update the contents of the file at given filePath
-          // eslint-disable-next-line no-await-in-loop
-          await updateFile(
+          promisedUpdates.push(updateFile(
             filePath,
             fileContent,
             contentBlock.matchRegex,
@@ -293,7 +292,7 @@ async function readAndUpdateFeatureFiles(
               contentBlock.replace.includes('${') ?
                 pascalName :
                 contentBlock.replace,
-          );
+          ));
         }
       }
     } else if (file.content) {
@@ -305,6 +304,7 @@ async function readAndUpdateFeatureFiles(
       );
     }
   }
+  await Promise.all(promisedUpdates);
 }
 
 /**

--- a/src/lib/stdout.ts
+++ b/src/lib/stdout.ts
@@ -1,0 +1,15 @@
+import util from 'util';
+/**
+ * Emulates the log method from @oclif/command, since they don't seem to be
+ * offering any alternatives. Can be replaced with another logging library.
+ * @param {any} message The content to print to the console
+ * @param {Array<any>} args See util.format for formatting arguments.
+ */
+function log(message: any = '', ...args: any[]): void {
+  message = typeof message === 'string' ? message : util.inspect(message);
+  process.stdout.write(`${util.format(message, ...args)}\n`);
+}
+
+export {
+  log,
+};

--- a/test/commands/add.component.test.ts
+++ b/test/commands/add.component.test.ts
@@ -6,7 +6,7 @@ import { exec } from 'child_process';
 const skipPresets = '--skipPresets';
 const testProjectName = 'rdv-component-test';
 const testComponentName = 'hello-world';
-// const badComponentName = 'he%20-2world';
+const { log } = console;
 
 describe(CLI_COMMANDS.AddComponent, () => {
   test
@@ -26,20 +26,10 @@ describe(CLI_COMMANDS.AddComponent, () => {
       expect(ctx.stdout).to.contain(`[rdvue] component added: ${testComponentName}`);
     });
 
-  // test
-  //   .stdout()
-  //   .do(() => process.chdir(testProjectName))
-  //   .command([CLI_COMMANDS.AddComponent, badComponentName])
-  //   .do(() => process.chdir('../'))
-  //   .it('tries to run create component with a poorly formatted command', ctx => {
-  //     expect(ctx.stdout).to.contain(`Error: command ${CLI_COMMANDS.AddComponent} not found`);
-  //   });
-
   after(() => {
     exec(`rm -r ${testProjectName}`, error => {
       if (error) {
-        // eslint-disable-next-line no-console
-        console.log(`error: ${error.message}`);
+        log(`error: ${error.message}`);
       }
     });
   });

--- a/test/lib/files.read-and-update-feature-files.test.ts
+++ b/test/lib/files.read-and-update-feature-files.test.ts
@@ -6,19 +6,18 @@ import { Files } from '../../src/modules';
 import { readAndUpdateFeatureFiles } from '../../src/lib/files';
 
 describe('lib/files.readAndUpdateFeatureFiles', () => {
-
   const matchRegex = '__VALUE__';
   const destDir = '';
   const dummyFile: { [key: string]: string } = {
     'file1.ts': `line 1\n${matchRegex}\nline 3\n`,
     'file2.ts': `${matchRegex}\nline 2\nline 3\n`,
     'file3.ts': `line 1\nline 2\n${matchRegex}\n`,
-  }
+  };
   let readFileSyncStub: sinon.SinonStub;
   let writeFileSyncStub: sinon.SinonStub;
 
   beforeEach(() => {
-    readFileSyncStub = sinon.stub(fs, 'readFileSync').callsFake((path) => {
+    readFileSyncStub = sinon.stub(fs, 'readFileSync').callsFake(path => {
       return dummyFile[path.toString()];
     });
     writeFileSyncStub = sinon.stub(fs, 'writeFileSync');
@@ -27,7 +26,7 @@ describe('lib/files.readAndUpdateFeatureFiles', () => {
   it('reads and updates feature files', async () => {
     const kebabName = 'component-name';
     const templateVariableName = 'componentName';
-    const pascalName = 'withPascalName'
+    const pascalName = 'withPascalName';
 
     const files: Array<Files> = [
       {
@@ -43,6 +42,7 @@ describe('lib/files.readAndUpdateFeatureFiles', () => {
         target: 'file2.ts',
         content: [{
           matchRegex,
+          // eslint-disable-next-line no-template-curly-in-string
           replace: '${withTemplateVariable}',
         }],
       },
@@ -60,15 +60,15 @@ describe('lib/files.readAndUpdateFeatureFiles', () => {
     expect(writeFileSyncStub.calledWith(...[
       `${destDir}${files[0].target}`,
       `line 1\n${kebabName}\nline 3\n`,
-    ])).to.be.true;
+    ])).to.equal(true);
     expect(writeFileSyncStub.calledWith(...[
       `${destDir}${files[1].target}`,
       `${templateVariableName}\nline 2\nline 3\n`,
-    ])).to.be.true;
+    ])).to.equal(true);
     expect(writeFileSyncStub.calledWith(...[
       `${destDir}${files[2].target}`,
       `line 1\nline 2\n${pascalName}\n`,
-    ])).to.be.true;
+    ])).to.equal(true);
   });
 
   it('copies files?', async () => {
@@ -79,7 +79,7 @@ describe('lib/files.readAndUpdateFeatureFiles', () => {
       {
         source: 'file1.ts',
         target: 'file1.ts',
-      }
+      },
     ];
 
     await readAndUpdateFeatureFiles(destDir, files, kebabName, templateVariableName);

--- a/test/lib/files.readAndUpdateFeatureFiles.test.ts
+++ b/test/lib/files.readAndUpdateFeatureFiles.test.ts
@@ -1,0 +1,92 @@
+/* global beforeEach, afterEach */
+import sinon from 'sinon';
+import fs from 'fs';
+import { expect } from 'chai';
+import { Files } from '../../src/modules';
+import { readAndUpdateFeatureFiles } from '../../src/lib/files';
+
+describe('lib/files.readAndUpdateFeatureFiles', () => {
+
+  const matchRegex = '__VALUE__';
+  const destDir = '';
+  const dummyFile: { [key: string]: string } = {
+    'file1.ts': `line 1\n${matchRegex}\nline 3\n`,
+    'file2.ts': `${matchRegex}\nline 2\nline 3\n`,
+    'file3.ts': `line 1\nline 2\n${matchRegex}\n`,
+  }
+  let readFileSyncStub: sinon.SinonStub;
+  let writeFileSyncStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    readFileSyncStub = sinon.stub(fs, 'readFileSync').callsFake((path) => {
+      return dummyFile[path.toString()];
+    });
+    writeFileSyncStub = sinon.stub(fs, 'writeFileSync');
+  });
+
+  it('reads and updates feature files', async () => {
+    const kebabName = 'component-name';
+    const templateVariableName = 'componentName';
+    const pascalName = 'withPascalName'
+
+    const files: Array<Files> = [
+      {
+        source: 'file1.ts',
+        target: 'file1.ts',
+        content: [{
+          matchRegex,
+          replace: 'withKebabName',
+        }],
+      },
+      {
+        source: 'file2.ts',
+        target: 'file2.ts',
+        content: [{
+          matchRegex,
+          replace: '${withTemplateVariable}',
+        }],
+      },
+      {
+        source: 'file3.ts',
+        target: 'file3.ts',
+        content: [{
+          matchRegex,
+          replace: pascalName,
+        }],
+      },
+    ];
+
+    await readAndUpdateFeatureFiles(destDir, files, kebabName, templateVariableName);
+    expect(writeFileSyncStub.calledWith(...[
+      `${destDir}${files[0].target}`,
+      `line 1\n${kebabName}\nline 3\n`,
+    ])).to.be.true;
+    expect(writeFileSyncStub.calledWith(...[
+      `${destDir}${files[1].target}`,
+      `${templateVariableName}\nline 2\nline 3\n`,
+    ])).to.be.true;
+    expect(writeFileSyncStub.calledWith(...[
+      `${destDir}${files[2].target}`,
+      `line 1\nline 2\n${pascalName}\n`,
+    ])).to.be.true;
+  });
+
+  it('copies files?', async () => {
+    const kebabName = 'component-name';
+    const templateVariableName = 'componentName';
+
+    const files: Array<Files> = [
+      {
+        source: 'file1.ts',
+        target: 'file1.ts',
+      }
+    ];
+
+    await readAndUpdateFeatureFiles(destDir, files, kebabName, templateVariableName);
+  });
+
+  afterEach(() => {
+    readFileSyncStub.restore();
+    writeFileSyncStub.restore();
+  });
+});

--- a/test/lib/stdout.test.ts
+++ b/test/lib/stdout.test.ts
@@ -1,0 +1,38 @@
+import sinon, { SinonStub } from 'sinon';
+import { expect } from 'chai';
+
+import { format } from 'util';
+import { log } from '../../src/lib/stdout';
+
+const { stdout } = process;
+
+describe('lib/stdout.log', () => {
+  let writeStub: SinonStub;
+
+  beforeEach(() => {
+    writeStub = sinon.stub(stdout, 'write');
+  });
+
+  it('default - prints an empty message', () => {
+    log();
+    expect(writeStub.lastCall.args).to.include('\n');
+  });
+
+  it('default - prints a string', () => {
+    const message = 'my message';
+    log(message);
+    expect(writeStub.lastCall.args).to.include(`${message}\n`);
+  });
+
+  it('default - prints a not string', () => {
+    const message = {
+      key: 'value',
+    };
+    log(message);
+    expect(writeStub.lastCall.args).to.include(`${format(message)}\n`);
+  });
+
+  afterEach(() => {
+    writeStub.restore();
+  });
+});


### PR DESCRIPTION
# Tickets
- https://realdecoy.atlassian.net/browse/SEPA-418

# Changes
- Added stdout library to assist with logging.
- Added unit tests to cover stdout.
- Added unit tests to cover changes to `readAndUpdateFeatureFiles` in `files.ts`
- Added mocha to eslintrc environment.
- Refactored run methods. Replaced switch with if statement.
- Removed commented code.
- Removed most of the eslint-disable statements

# Notes
I was unable to remove eslint-disable statements for "max-lines" and "no-constant-condition". Removing these statements will require some thoughtful refactoring. As I understand, the related scripts are slated for refactoring anyways. Affected Files:
- src/lib/files.ts
- src/lib/utilities.ts

In addition to the above, I have introduced `eslint-disable-next-line no-template-curly-in-string` in my test file `test/lib/files.read-and-update-feature-files.test.ts`. I believe that the rule should not be removed since it has real applicable scenarios; however I needed to disable it in this scenario, since I needed a literal string containing '${ ... }' as my sample data.

