### PR TITLE
SEPA-407: inject routes directly into the router

### DIFF
--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -76,7 +76,7 @@ function readConfigFile(filePath: string): any {
  * @param {string} projectRoot -
  * @returns {[any]} -
  */
-function parseModuleConfig(folderList: string[], projectRoot: string): {name: string, moduleTemplatePath: string, manifest: any}[] {
+function parseModuleConfig(folderList: string[], projectRoot: string): { name: string, moduleTemplatePath: string, manifest: any }[] {
   return folderList.map(folder => {
     const moduleTemplatePath = path.join(projectRoot, TEMPLATE_ROOT, folder);
     const configFilePath = path.join(moduleTemplatePath, TEMPLATE_CONFIG_FILENAME);
@@ -451,8 +451,7 @@ function parseDynamicObjects(
     const originalObjectString = objectInProject.slice(0, -2);
 
     // Append the new information and close files after changes
-    objectStringToBeWritten = `${originalObjectString}${modifiedJSONData.trim()},${objectName === DYNAMIC_OBJECTS.Routes ? ']' : '}'
-    };`;
+    objectStringToBeWritten = `${originalObjectString}${modifiedJSONData.trim()},${objectName === DYNAMIC_OBJECTS.Routes ? ']' : '}'};`;
   }
 
   // 1[c] Once everything is clear write the updated file into the ./rdvue foldler
@@ -482,7 +481,7 @@ function inject(targetPath: string, content: string, options?: InjectOptions): v
   const lines = targetContent.split(/\r?\n/g);
 
   if (typeof index === 'function') {
-    index = index(lines.slice());
+    index = index(lines.slice(), targetPath);
   }
 
   lines.splice(index, 0, content);

--- a/src/modules/file.ts
+++ b/src/modules/file.ts
@@ -1,16 +1,16 @@
 export interface FilesContent {
-    matchRegex: string;
-    replace: string;
+  matchRegex: string;
+  replace: string;
 }
 
 export interface Files {
-    source: string;
-    target: string;
-    content?: FilesContent[];
+  source: string;
+  target: string;
+  content?: FilesContent[];
 }
 
 export type InjectOptions = {
-  index?: number | ((lines: string[]) => number);
+  index?: number | ((lines: string[], filePath: string) => number);
   encoding?: string;
 }
 

--- a/src/modules/manifest.ts
+++ b/src/modules/manifest.ts
@@ -1,0 +1,10 @@
+export interface RouteMeta {
+  layout: string
+}
+
+export interface Route {
+  path: string;
+  name: string;
+  meta?: RouteMeta;
+  component: string;
+}


### PR DESCRIPTION
# Tickets
- https://realdecoy.atlassian.net/browse/SEPA-407

# Changes
- added Route interface to handle expected Route model
- added target path as argument to inject's index callback
- refactored buefy plugin to inject routes directly into router.ts
- refactored InjectOptions to include filepath argument in index callback
- cleaned up linter errors.

# Notes
These changes will require the manifest in the buefy plugin to be altered slightly:

- The back ticks in the component need to be removed
```
"component": "`require('@/pages/buefy-sample/buefy-sample.vue').default`"
```
Changed to
```
"component": "require('@/pages/buefy-sample/buefy-sample.vue').default"
```
