### PR TITLE
fix: Only remove .rdvue file if not directory

### DIFF
--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -371,7 +371,7 @@ function getProjectRoot(): string | null {
   const configFolderName = RDVUE_DIRECTORY;
   const currentConfigFolder = path.join(process.cwd(), configFolderName);
   // Check if the current directory is the root of the project for older versions of rdvue
-  if (fileExists(currentConfigFolder)) {
+  if (fileExists(currentConfigFolder) && !fs.lstatSync(currentConfigFolder).isDirectory()) {
     deleteFile(currentConfigFolder);
 
     return process.cwd();


### PR DESCRIPTION
On some versions of RDVue projects, the .rdvue file is located inside the .rdvue folder. This change prevents the application from breaking when only the folder is detected in the project root.