### PR TITLE
Fix/feature name validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2536,7 +2536,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastq": {
       "version": "1.11.0",
@@ -3434,7 +3434,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -3569,7 +3569,7 @@
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "lodash.upperfirst": {
@@ -3915,7 +3915,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "natural-orderby": {
       "version": "2.0.3",
@@ -5198,7 +5198,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "through": {
       "version": "2.3.8",

--- a/src/commands/add/layout.ts
+++ b/src/commands/add/layout.ts
@@ -1,0 +1,92 @@
+import Command, { flags } from "@oclif/command";
+import path from 'path';
+import { checkProjectValidity, isJsonString, parseLayoutName, parsePageName, toKebabCase, toPascalCase } from "../../lib/utilities";
+import chalk from "chalk";
+import { CLI_STATE, CLI_COMMANDS, DOCUMENTATION_LINKS } from "../../lib/constants";
+import { copyFiles, parseModuleConfig, readAndUpdateFeatureFiles, replaceTargetFileNames } from "../../lib/files";
+import { Files } from "../../modules";
+
+const TEMPLATE_FOLDERS = ['layout'];
+const CUSTOM_ERROR_MESSAGES = [
+  'project-invalid',
+  'failed-match-and-replace',
+  'missing-template-file',
+  'missing-template-folder',
+];
+
+export default class Layout extends Command {
+  static description = 'add a new Layout module.'
+
+  static flags = {
+    help: flags.help({ char: 'h' }),
+  }
+
+  static args = [
+    { name: 'name', description: 'name of new layout' },
+  ]
+
+  // override Command class error handler
+  catch(error: Error): Promise<any> {
+    const errorMessage = error.message;
+    const isValidJSON = isJsonString(errorMessage);
+    const parsedError = isValidJSON ? JSON.parse(errorMessage) : {};
+    const customErrorCode = parsedError.code;
+    const customErrorMessage = parsedError.message;
+    const hasCustomErrorCode = customErrorCode !== undefined;
+
+    if (hasCustomErrorCode === false) {
+      // throw cli errors to be handled globally
+      throw errorMessage;
+    }
+
+    // handle errors thrown with known error codes
+    if (CUSTOM_ERROR_MESSAGES.includes(customErrorCode)) {
+      this.log(`${CLI_STATE.Error} ${customErrorMessage}`);
+    } else {
+      throw new Error(customErrorMessage);
+    }
+
+    return Promise.resolve();
+  }
+
+  async run(): Promise<void> {
+    const { isValid: isValidProject, projectRoot } = checkProjectValidity();
+    // block command unless being run within an rdvue project
+    if (isValidProject === false) {
+      throw new Error(
+        JSON.stringify({
+          code: 'project-invalid',
+          message: `${CLI_COMMANDS.AddLayout} command must be run in an existing ${chalk.yellow('rdvue')} project`,
+        }),
+      );
+    }
+
+    const { args } = this.parse(Layout);
+    const folderList = TEMPLATE_FOLDERS;
+    let sourceDirectory: string;
+    let installDirectory: string;
+    // let templateFile: string;
+
+    const configs = parseModuleConfig(folderList, projectRoot);
+
+    const layoutName = await parseLayoutName(args);
+    // parse kebab and pascal case of layoutName
+    const layoutNameKebab = toKebabCase(layoutName);
+    const layoutNamePascal = toPascalCase(layoutName);
+
+    configs.forEach(async config => {
+      const files: Array<string | Files> = config.manifest.files;
+      // replace file names in config with kebab case equivalent
+      replaceTargetFileNames(files, layoutNameKebab);
+      sourceDirectory = path.join(config.moduleTemplatePath, config.manifest.sourceDirectory);
+      installDirectory = path.join(projectRoot, 'src', config.manifest.installDirectory, layoutNameKebab);
+
+      // copy and update files for page being added
+      await copyFiles(sourceDirectory, installDirectory, files);
+      await readAndUpdateFeatureFiles(installDirectory, files, layoutNameKebab, layoutNamePascal);
+    });
+
+    this.log(`${CLI_STATE.Success} layout added: ${layoutNameKebab}`);
+    this.log(`\n  Visit the documentation page for more info:\n  ${chalk.yellow(DOCUMENTATION_LINKS.Layout)}\n`);
+  }
+}

--- a/src/commands/add/layout.ts
+++ b/src/commands/add/layout.ts
@@ -1,10 +1,10 @@
-import Command, { flags } from "@oclif/command";
+import Command, { flags } from '@oclif/command';
 import path from 'path';
-import { checkProjectValidity, isJsonString, parseLayoutName, parsePageName, toKebabCase, toPascalCase } from "../../lib/utilities";
-import chalk from "chalk";
-import { CLI_STATE, CLI_COMMANDS, DOCUMENTATION_LINKS } from "../../lib/constants";
-import { copyFiles, parseModuleConfig, readAndUpdateFeatureFiles, replaceTargetFileNames } from "../../lib/files";
-import { Files } from "../../modules";
+import { checkProjectValidity, isJsonString, parseLayoutName, toKebabCase, toPascalCase } from '../../lib/utilities';
+import chalk from 'chalk';
+import { CLI_STATE, CLI_COMMANDS, DOCUMENTATION_LINKS } from '../../lib/constants';
+import { copyFiles, parseModuleConfig, readAndUpdateFeatureFiles, replaceTargetFileNames } from '../../lib/files';
+import { Files } from '../../modules';
 
 const TEMPLATE_FOLDERS = ['layout'];
 const CUSTOM_ERROR_MESSAGES = [

--- a/src/commands/upgrade/index.ts
+++ b/src/commands/upgrade/index.ts
@@ -71,7 +71,7 @@ export default class Upgrade extends Command {
     await shell.exec(`git clone ${template} --depth 1 --branch ${versionName} ${temporaryProjectFolder}`, { silent: true });
 
     // copy template files to project local template storage
-    const result = await copyDirectoryRecursive(templateSourcePath, templateDestinationPath);
+    await copyDirectoryRecursive(templateSourcePath, templateDestinationPath);
     /**
      * @Todo create method to generate changelog dynamically from git diff.
      * add changelog to project temp directory and read based on release version number
@@ -213,6 +213,7 @@ export default class Upgrade extends Command {
 
   jsonReader(filePath: string): any {
     const text = fs.readFileSync(filePath);
+
     return JSON.parse(text);
   }
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -30,7 +30,7 @@ enum CLI_COMMANDS_ENUM {
   AddPage = 'add:page',
   AddService = 'add:service',
   AddStore = 'add:store',
-  AddLayout = "add:layout",
+  AddLayout = 'add:layout',
   AddModule = 'add',
   PluginBuefy = 'plugin:buefy',
   PluginLocalization = 'plugin:localization',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -30,6 +30,7 @@ enum CLI_COMMANDS_ENUM {
   AddPage = 'add:page',
   AddService = 'add:service',
   AddStore = 'add:store',
+  AddLayout = "add:layout",
   AddModule = 'add',
   PluginBuefy = 'plugin:buefy',
   PluginLocalization = 'plugin:localization',
@@ -42,6 +43,7 @@ export const CLI_COMMANDS = CLI_COMMANDS_ENUM;
 enum DOCUMENTATION_LINKS_ENUM {
   Rdvue = 'https://realdecoy.github.io/rdvue/#/',
   Component = 'https://realdecoy.github.io/rdvue/#/Features?id=components',
+  Layout = 'https://realdecoy.github.io/rdvue/#/Features?id=layouts',
   Page = 'https://realdecoy.github.io/rdvue/#/Features?id=pages',
   Service = 'https://realdecoy.github.io/rdvue/#/Features?id=services',
   Store = 'https://realdecoy.github.io/rdvue/#/Features?id=stores',

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import fileSystem from 'fs';
-const fs_sync = require('fs');
+const fsSync = require('fs');
 import bluebirdPromise from 'bluebird';
 import path from 'path';
 import mkdirp from 'mkdirp';
@@ -201,10 +201,10 @@ function replaceTargetFileNames(
 async function copyDirectoryRecursive(source: string, target: string): Promise<boolean> {
   let success = false;
   if (directoryExists(target)) {
-    fs_sync.rmdirSync(target, { recursive: true });
-    fs_sync.mkdirSync(target);
+    fsSync.rmdirSync(target, { recursive: true });
+    fsSync.mkdirSync(target);
   } else {
-    fs_sync.mkdirSync(target);
+    fsSync.mkdirSync(target);
   }
   try {
     await ncp(source, target);

--- a/src/lib/utilities.ts
+++ b/src/lib/utilities.ts
@@ -63,7 +63,7 @@ function toPascalCase(value: string): string {
 
 /**
  * Description: remove the prefix '[rdvue]' from a string
- * @param value - a string value
+ * @param {string} value - a string value
  * @returns {string} - a string with the prefix '[rdvue]' removed
  */
 function stripRdvuePrefix(value: string): string {
@@ -72,8 +72,8 @@ function stripRdvuePrefix(value: string): string {
 
 /**
  * Description: Throwsan error with the provided message
- * @param errorMessage - error message to be thrown
- * @throws {Error} 
+ * @param {string} errorMessage - error message to be thrown
+ * @throws {Error}
  */
 function throwNameError(errorMessage: string): void {
   throw new Error(
@@ -117,6 +117,7 @@ async function parseComponentName(args: Lookup): Promise<string> {
   let argName = args.name;
   const validateComponentName = validateEnteredName('component');
   // if no component name is provided in command then prompt user
+  // eslint-disable-next-line no-negated-condition
   if (!argName) {
     const responses: any = await inquirer.prompt([{
       name: 'name',
@@ -145,6 +146,7 @@ async function parseProjectName(args: Lookup): Promise<string> {
   let argName = args.name;
   const validateProjectName = validateEnteredName('project');
   // if no project name is provided in command then prompt user
+  // eslint-disable-next-line no-negated-condition
   if (!argName) {
     const responses: any = await inquirer.prompt([{
       name: 'name',
@@ -156,7 +158,7 @@ async function parseProjectName(args: Lookup): Promise<string> {
     argName = responses.name;
   } else {
     const result = validateProjectName(argName);
-    if (result && result != true) {
+    if (result && result !== true) {
       throwNameError(result);
     }
   }
@@ -173,6 +175,7 @@ async function parseLayoutName(args: Lookup): Promise<string> {
   let argName = args.name;
   const validateLayoutName = validateEnteredName('layout');
   // if no layout name is provided in command then prompt user
+  // eslint-disable-next-line no-negated-condition
   if (!argName) {
     const responses: any = await inquirer.prompt([{
       name: 'name',
@@ -184,7 +187,7 @@ async function parseLayoutName(args: Lookup): Promise<string> {
     argName = responses.name;
   } else {
     const result = validateLayoutName(argName);
-    if (result && result != true) {
+    if (result && result !== true) {
       throwNameError(result);
     }
   }
@@ -201,6 +204,7 @@ async function parseVersionName(args: Lookup): Promise<string> {
   let argName = args.name;
   const validateVersionName = validateEnteredName('version');
   // if no page name is provided in command then prompt user
+  // eslint-disable-next-line no-negated-condition
   if (!argName) {
     const responses: any = await inquirer.prompt([{
       name: 'name',
@@ -212,7 +216,7 @@ async function parseVersionName(args: Lookup): Promise<string> {
     argName = responses.name;
   } else {
     const result = validateVersionName(argName);
-    if (result && result != true) {
+    if (result && result !== true) {
       throwNameError(result);
     }
   }
@@ -228,6 +232,7 @@ async function parseVersionName(args: Lookup): Promise<string> {
 async function parseProjectPresets(args: Lookup): Promise<string> {
   let argName = args.preset;
   // if no project name is provided in command then prompt user
+  // eslint-disable-next-line no-negated-condition
   if (!argName) {
     const responses: any = await inquirer.prompt([{
       name: 'preset',
@@ -251,6 +256,7 @@ async function parsePageName(args: Lookup): Promise<string> {
   let argName = args.name;
   const validatePageName = validateEnteredName('page');
   // if no page name is provided in command then prompt user
+  // eslint-disable-next-line no-negated-condition
   if (!argName) {
     const responses: any = await inquirer.prompt([{
       name: 'name',
@@ -262,7 +268,7 @@ async function parsePageName(args: Lookup): Promise<string> {
     argName = responses.name;
   } else {
     const result = validatePageName(argName);
-    if (result && result != true) {
+    if (result && result !== true) {
       throwNameError(result);
     }
   }
@@ -279,6 +285,7 @@ async function parseServiceName(args: Lookup): Promise<string> {
   let argName = args.name;
   const validateServiceName = validateEnteredName('service');
   // if no page name is provided in command then prompt user
+  // eslint-disable-next-line no-negated-condition
   if (!argName) {
     const responses: any = await inquirer.prompt([{
       name: 'name',
@@ -290,7 +297,7 @@ async function parseServiceName(args: Lookup): Promise<string> {
     argName = responses.name;
   } else {
     const result = validateServiceName(argName);
-    if (result && result != true) {
+    if (result && result !== true) {
       throwNameError(result);
     }
   }
@@ -307,6 +314,7 @@ async function parseStoreModuleName(args: Lookup): Promise<string> {
   let argName = args.name;
   const validateStoreModuleName = validateEnteredName('store', 'auth-store');
   // if no page name is provided in command then prompt user
+  // eslint-disable-next-line no-negated-condition
   if (!argName) {
     const responses: any = await inquirer.prompt([{
       name: 'name',
@@ -318,7 +326,7 @@ async function parseStoreModuleName(args: Lookup): Promise<string> {
     argName = responses.name;
   } else {
     const result = validateStoreModuleName(argName);
-    if (result && result != true) {
+    if (result && result !== true) {
       throwNameError(result);
     }
   }

--- a/src/lib/utilities.ts
+++ b/src/lib/utilities.ts
@@ -63,10 +63,11 @@ function toPascalCase(value: string): string {
 
 /**
  * Description: determine if string is valid component name
- * @param {string} value - a string value
+ * @param {string} featureName - the name of the feature whose name is being validated
+ * @param {string} exampleName - an example of a valid name
  * @returns {any} -
  */
-function validateEnteredName(elementName: string, exampleName = '') {
+function validateEnteredName(featureName: string, exampleName = '') {
   return (value: any) => {
     const isString = typeof value === 'string';
     const isNull = value === null || value.length === 0;
@@ -76,13 +77,13 @@ function validateEnteredName(elementName: string, exampleName = '') {
     let resultMessage;
 
     if (isNull) {
-      resultMessage = `${CLI_STATE.Error} A ${elementName} name is required`;
+      resultMessage = `${CLI_STATE.Error} A ${featureName} name is required`;
     } else if (!charactersMatch) {
-      resultMessage = `${CLI_STATE.Error} Use letters, numbers and '-' for ${elementName} names (e.g. ${exampleName ? exampleName : 'my-' + elementName + '-name'})`;
+      resultMessage = `${CLI_STATE.Error} Use letters, numbers and '-' for ${featureName} names (e.g. ${exampleName ? exampleName : `my-${featureName}-name`})`;
     }
 
     return isValidName ? true : resultMessage;
-  }
+  };
 }
 
 /**

--- a/src/lib/utilities.ts
+++ b/src/lib/utilities.ts
@@ -71,7 +71,7 @@ function stripRdvuePrefix(value: string): string {
 }
 
 /**
- * Description: Throwsan error with the provided message
+ * Description: Throws an error with the provided message
  * @param {string} errorMessage - error message to be thrown
  * @throws {Error}
  */

--- a/src/lib/utilities.ts
+++ b/src/lib/utilities.ts
@@ -62,6 +62,29 @@ function toPascalCase(value: string): string {
 }
 
 /**
+ * Description: remove the prefix '[rdvue]' from a string
+ * @param value - a string value
+ * @returns {string} - a string with the prefix '[rdvue]' removed
+ */
+function stripRdvuePrefix(value: string): string {
+  return value.replace('[rdvue]', '');
+}
+
+/**
+ * Description: Throwsan error with the provided message
+ * @param errorMessage - error message to be thrown
+ * @throws {Error} 
+ */
+function throwNameError(errorMessage: string): void {
+  throw new Error(
+    JSON.stringify({
+      code: 'name-invalid',
+      message: stripRdvuePrefix(errorMessage),
+    }),
+  );
+}
+
+/**
  * Description: determine if string is valid component name
  * @param {string} featureName - the name of the feature whose name is being validated
  * @param {string} exampleName - an example of a valid name
@@ -75,7 +98,6 @@ function validateEnteredName(featureName: string, exampleName = '') {
     const charactersMatch = value.match(/^[a-zA-Z0-9.\-_]+$/i) !== null;
     const isValidName = isString && charactersMatch;
     let resultMessage;
-
     if (isNull) {
       resultMessage = `${CLI_STATE.Error} A ${featureName} name is required`;
     } else if (!charactersMatch) {
@@ -104,6 +126,11 @@ async function parseComponentName(args: Lookup): Promise<string> {
       validate: validateComponentName,
     }]);
     argName = responses.name;
+  } else {
+    const result = validateComponentName(argName);
+    if (result && result !== true) {
+      throwNameError(result);
+    }
   }
 
   return argName;
@@ -127,6 +154,11 @@ async function parseProjectName(args: Lookup): Promise<string> {
       validate: validateProjectName,
     }]);
     argName = responses.name;
+  } else {
+    const result = validateProjectName(argName);
+    if (result && result != true) {
+      throwNameError(result);
+    }
   }
 
   return argName;
@@ -150,6 +182,11 @@ async function parseLayoutName(args: Lookup): Promise<string> {
       validate: validateLayoutName,
     }]);
     argName = responses.name;
+  } else {
+    const result = validateLayoutName(argName);
+    if (result && result != true) {
+      throwNameError(result);
+    }
   }
 
   return argName;
@@ -173,6 +210,11 @@ async function parseVersionName(args: Lookup): Promise<string> {
       validate: validateVersionName,
     }]);
     argName = responses.name;
+  } else {
+    const result = validateVersionName(argName);
+    if (result && result != true) {
+      throwNameError(result);
+    }
   }
 
   return argName;
@@ -218,6 +260,11 @@ async function parsePageName(args: Lookup): Promise<string> {
       validate: validatePageName,
     }]);
     argName = responses.name;
+  } else {
+    const result = validatePageName(argName);
+    if (result && result != true) {
+      throwNameError(result);
+    }
   }
 
   return argName;
@@ -241,6 +288,11 @@ async function parseServiceName(args: Lookup): Promise<string> {
       validate: validateServiceName,
     }]);
     argName = responses.name;
+  } else {
+    const result = validateServiceName(argName);
+    if (result && result != true) {
+      throwNameError(result);
+    }
   }
 
   return argName;
@@ -264,6 +316,11 @@ async function parseStoreModuleName(args: Lookup): Promise<string> {
       validate: validateStoreModuleName,
     }]);
     argName = responses.name;
+  } else {
+    const result = validateStoreModuleName(argName);
+    if (result && result != true) {
+      throwNameError(result);
+    }
   }
 
   return argName;

--- a/src/lib/utilities.ts
+++ b/src/lib/utilities.ts
@@ -62,145 +62,38 @@ function toPascalCase(value: string): string {
 }
 
 /**
- * Description: determine if string is valid project name
- * @param {string} value - a string value
- * @returns {any} -
- */
-function validateProjectName(value: any) {
-  const isString = typeof value === 'string';
-  const isNull = value === null || value.length === 0;
-  // characters in value are limited to alphanumeric characters and hyphens or underscores
-  const charactersMatch = value.match(/^[a-zA-Z0-9.\-_]+$/i) !== null;
-  const isValidProjectName = isString && charactersMatch;
-  let resultMessage;
-
-  if (isNull) {
-    resultMessage = `${CLI_STATE.Error} A project name is required`;
-  } else if (!charactersMatch) {
-    resultMessage = `${CLI_STATE.Error} Use letters, numbers and '-' for project names (e.g. my-project-name)`;
-  }
-
-  return isValidProjectName ? true : resultMessage;
-}
-
-/**
  * Description: determine if string is valid component name
  * @param {string} value - a string value
  * @returns {any} -
  */
-function validateComponentName(value: any) {
-  const isString = typeof value === 'string';
-  const isNull = value === null || value.length === 0;
-  // characters in value are limited to alphanumeric characters and hyphens or underscores
-  const charactersMatch = value.match(/^[a-zA-Z0-9.\-_]+$/i) !== null;
-  const isValidComponentName = isString && charactersMatch;
-  let resultMessage;
+function validateEnteredName(elementName: string, exampleName = '') {
+  return (value: any) => {
+    const isString = typeof value === 'string';
+    const isNull = value === null || value.length === 0;
+    // characters in value are limited to alphanumeric characters and hyphens or underscores
+    const charactersMatch = value.match(/^[a-zA-Z0-9.\-_]+$/i) !== null;
+    const isValidName = isString && charactersMatch;
+    let resultMessage;
 
-  if (isNull) {
-    resultMessage = `${CLI_STATE.Error} A component name is required`;
-  } else if (!charactersMatch) {
-    resultMessage = `${CLI_STATE.Error} Use letters, numbers and '-' for component names (e.g. my-component-name)`;
+    if (isNull) {
+      resultMessage = `${CLI_STATE.Error} A ${elementName} name is required`;
+    } else if (!charactersMatch) {
+      resultMessage = `${CLI_STATE.Error} Use letters, numbers and '-' for ${elementName} names (e.g. ${exampleName ? exampleName : 'my-' + elementName + '-name'})`;
+    }
+
+    return isValidName ? true : resultMessage;
   }
-
-  return isValidComponentName ? true : resultMessage;
 }
 
 /**
- * Description: determine if string is valid version name
- * @param {string} value - a string value
- * @returns {any} -
- */
-function validateVersionName(value: any) {
-  const isString = typeof value === 'string';
-  const isNull = value === null || value.length === 0;
-  // characters in value are limited to alphanumeric characters and hyphens or underscores
-  const charactersMatch = value.match(/^[a-zA-Z0-9.\-_]+$/i) !== null;
-  const isValidVersionName = isString && charactersMatch;
-  let resultMessage;
-
-  if (isNull) {
-    resultMessage = `${CLI_STATE.Error} A version name is required`;
-  } else if (!charactersMatch) {
-    resultMessage = `${CLI_STATE.Error} Use letters, numbers and '-' for version names (e.g. my-version-name)`;
-  }
-
-  return isValidVersionName ? true : resultMessage;
-}
-
-/**
- * Description: determine if string is valid page name
- * @param {string} value - a string value
- * @returns {any} -
- */
-function validatePageName(value: any) {
-  const isString = typeof value === 'string';
-  const isNull = value === null || value.length === 0;
-  // characters in value are limited to alphanumeric characters and hyphens or underscores
-  const charactersMatch = value.match(/^[a-zA-Z0-9.\-_]+$/i) !== null;
-  const isValidArgName = isString && charactersMatch;
-  let resultMessage;
-
-  if (isNull) {
-    resultMessage = `${CLI_STATE.Error} A page name is required`;
-  } else if (!charactersMatch) {
-    resultMessage = `${CLI_STATE.Error} Use letters, numbers and '-' for page names (e.g. page-name)`;
-  }
-
-  return isValidArgName ? true : resultMessage;
-}
-
-/**
- * Description: determine if string is valid service name
- * @param {string} value - a string value
- * @returns {any} -
- */
-function validateServiceName(value: any) {
-  const isString = typeof value === 'string';
-  const isNull = value === null || value.length === 0;
-  // characters in value are limited to alphanumeric characters and hyphens or underscores
-  const charactersMatch = value.match(/^[a-zA-Z0-9.\-_]+$/i) !== null;
-  const isValidArgName = isString && charactersMatch;
-  let resultMessage;
-
-  if (isNull) {
-    resultMessage = `${CLI_STATE.Error} A service name is required`;
-  } else if (!charactersMatch) {
-    resultMessage = `${CLI_STATE.Error} Use letters, numbers and '-' for service names (e.g. service-name)`;
-  }
-
-  return isValidArgName ? true : resultMessage;
-}
-
-/**
- * Description: determine if string is valid store module name
- * @param {string | null} value - a string value
- * @returns {any} -
- */
-function validateStoreModuleName(value: any) {
-  const isString = typeof value === 'string';
-  const isNull = value === null || value.length === 0;
-  // characters in value are limited to alphanumeric characters and hyphens or underscores
-  const charactersMatch = value.match(/^[a-zA-Z0-9.\-_]+$/i) !== null;
-  const isValidArgName = isString && charactersMatch;
-  let resultMessage;
-
-  if (isNull) {
-    resultMessage = `${CLI_STATE.Error} A store module name is required`;
-  } else if (!charactersMatch) {
-    resultMessage = `${CLI_STATE.Error} Use letters, numbers and '-' for store module names (e.g. auth-store)`;
-  }
-
-  return isValidArgName ? true : resultMessage;
-}
-
-/**
- * Description: parse project or prompt user to provide name for project
- * @param {Lookup} args - a string value
- * @returns {string} -
+ * Description: parse component or prompt user to provide name for component
+ * @param {string} args - a string value
+ * @returns {Lookup} -
  */
 async function parseComponentName(args: Lookup): Promise<string> {
   let argName = args.name;
-  // if no page name is provided in command then prompt user
+  const validateComponentName = validateEnteredName('component');
+  // if no component name is provided in command then prompt user
   if (!argName) {
     const responses: any = await inquirer.prompt([{
       name: 'name',
@@ -222,6 +115,7 @@ async function parseComponentName(args: Lookup): Promise<string> {
  */
 async function parseProjectName(args: Lookup): Promise<string> {
   let argName = args.name;
+  const validateProjectName = validateEnteredName('project');
   // if no project name is provided in command then prompt user
   if (!argName) {
     const responses: any = await inquirer.prompt([{
@@ -244,6 +138,7 @@ async function parseProjectName(args: Lookup): Promise<string> {
  */
 async function parseVersionName(args: Lookup): Promise<string> {
   let argName = args.name;
+  const validateVersionName = validateEnteredName('version');
   // if no page name is provided in command then prompt user
   if (!argName) {
     const responses: any = await inquirer.prompt([{
@@ -288,6 +183,7 @@ async function parseProjectPresets(args: Lookup): Promise<string> {
  */
 async function parsePageName(args: Lookup): Promise<string> {
   let argName = args.name;
+  const validatePageName = validateEnteredName('page');
   // if no page name is provided in command then prompt user
   if (!argName) {
     const responses: any = await inquirer.prompt([{
@@ -310,6 +206,7 @@ async function parsePageName(args: Lookup): Promise<string> {
  */
 async function parseServiceName(args: Lookup): Promise<string> {
   let argName = args.name;
+  const validateServiceName = validateEnteredName('service');
   // if no page name is provided in command then prompt user
   if (!argName) {
     const responses: any = await inquirer.prompt([{
@@ -332,6 +229,7 @@ async function parseServiceName(args: Lookup): Promise<string> {
  */
 async function parseStoreModuleName(args: Lookup): Promise<string> {
   let argName = args.name;
+  const validateStoreModuleName = validateEnteredName('store', 'auth-store');
   // if no page name is provided in command then prompt user
   if (!argName) {
     const responses: any = await inquirer.prompt([{

--- a/src/lib/utilities.ts
+++ b/src/lib/utilities.ts
@@ -132,6 +132,29 @@ async function parseProjectName(args: Lookup): Promise<string> {
 }
 
 /**
+ * Description: parse layout or prompt user to provide name for layout
+ * @param {string} args  - a string value
+ * @returns {Lookup} -
+ */
+async function parseLayoutName(args: Lookup): Promise<string> {
+  let argName = args.name;
+  const validateLayoutName = validateEnteredName('layout');
+  // if no layout name is provided in command then prompt user
+  if (!argName) {
+    const responses: any = await inquirer.prompt([{
+      name: 'name',
+      default: 'my-layout',
+      message: 'Enter a layout name: ',
+      type: 'input',
+      validate: validateLayoutName,
+    }]);
+    argName = responses.name;
+  }
+
+  return argName;
+}
+
+/**
  * Description: parse project or prompt user to provide name for template version
  * @param {Lookup} args - a string value
  * @returns {string} -
@@ -326,6 +349,7 @@ export {
   toKebabCase,
   toPascalCase,
   parseComponentName,
+  parseLayoutName,
   parseProjectName,
   parseProjectPresets,
   parseVersionName,

--- a/test/commands/add.layout.test.ts
+++ b/test/commands/add.layout.test.ts
@@ -28,9 +28,9 @@ describe(CLI_COMMANDS.AddLayout, () => {
   after(() => {
     exec(`rm -r ${testProjectName}`, error => {
       if (error) {
+        // eslint-disable-next-line no-console
         console.log(`error: ${error.message}`);
       }
     });
   });
-
 });

--- a/test/commands/add.layout.test.ts
+++ b/test/commands/add.layout.test.ts
@@ -1,0 +1,36 @@
+/* global after */
+import { expect, test } from '@oclif/test';
+import { CLI_COMMANDS } from '../../src/lib/constants';
+import { exec } from 'child_process';
+
+const skipPresets = '--skipPresets';
+const testProjectName = 'rdv-component-test';
+const testLayoutName = 'hello-world';
+
+describe(CLI_COMMANDS.AddLayout, () => {
+  test
+    .stdout()
+    .command([CLI_COMMANDS.AddLayout])
+    .it(`runs rdvue ${CLI_COMMANDS.AddLayout} ${testLayoutName} (outside project)`, ctx => {
+      expect(ctx.stdout).to.contain(`[rdvue] ${CLI_COMMANDS.AddLayout} command must be run in an existing rdvue project`);
+    });
+
+  test
+    .stdout()
+    .command([CLI_COMMANDS.CreateProject, testProjectName, skipPresets])
+    .do(() => process.chdir(testProjectName))
+    .command([CLI_COMMANDS.AddLayout, testLayoutName])
+    .do(() => process.chdir('../'))
+    .it(`runs rdvue ${CLI_COMMANDS.AddLayout} ${testLayoutName}`, ctx => {
+      expect(ctx.stdout).to.contain(`[rdvue] layout added: ${testLayoutName}`);
+    });
+
+  after(() => {
+    exec(`rm -r ${testProjectName}`, error => {
+      if (error) {
+        console.log(`error: ${error.message}`);
+      }
+    });
+  });
+
+});


### PR DESCRIPTION
I utilized the existing validation function to run the validation on the `argName` variable in the case it was provided.
Closes #199 

**Steps to test**
In an existing rdvue project, enter any command to generate a feature, I'll use the `component` in this case, and besure to include a name that doesn't match the regex: `/^[a-zA-Z0-9.\-_]+$/i`, I'll use`?`.
```bash
rdvue add:component ?
```

**Expected Behaviour**
```bash
    Error:  Use letters, numbers and '-' for component names (e.g. my-component-name)
```

**Actual Behaviour**
```bash
    Error:  Use letters, numbers and '-' for component names (e.g. my-component-name)
```

**Additional Notes**
Should be merged after [PR-198](https://github.com/realdecoy/rdvue/pull/198)